### PR TITLE
Adds new filters to QueryCriteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,21 @@
 [![npm](https://img.shields.io/npm/dt/stackerjs-db-file-adapter.svg)](https://www.npmjs.com/package/stackerjs-db-file-adapter)
 
 # StackerJS DB: File Adapter
-
 An adapter for file system database.
 
 ## Installation
-
 ```bash
-    npm run build
+npm install --save stackerjs-db-file-adapter
 ```
 
-## Testing
+## Usage
+You need to create a config folder with a file called db.js, as follows:
+```javascript
+// config/db.js
 
-```bash
-    npm run test
+module.exports = {
+    host: "path/to/host",
+    name: "database_name"
+}
 ```
+Now you're set to write your queries.

--- a/src/FileAdapter.js
+++ b/src/FileAdapter.js
@@ -136,6 +136,8 @@ export class FileAdapter
     {
         if (!filters) return () => true;
 
+        if (typeof filters === "function") return filters;
+
         let criteria = new QueryCriteria();
         return item => 
         {
@@ -149,7 +151,7 @@ export class FileAdapter
                     let [comp, value] = filters[key];
                     return (response =
                         response &&
-                        criteria[comp.toLowerCase()](item[key], value));
+                        criteria[comp.toLowerCase()](key, value)(item));
                 }
 
                 if (filters[key] && typeof filters[key] === "object")
@@ -157,11 +159,11 @@ export class FileAdapter
                         (response =
                                 response &&
                                 criteria[comp.toLowerCase()](
-                                    item[key],
+                                    key,
                                     filters[key][comp]
-                                )));
+                                )(item)));
 
-                response = criteria.eq(item[key], filters[key]);
+                response = criteria.eq(key, filters[key])(item);
             });
 
             return response;

--- a/src/QueryBuilder/QueryBuilderDelete.js
+++ b/src/QueryBuilder/QueryBuilderDelete.js
@@ -1,0 +1,16 @@
+import { QueryBuilderQueries } from "./QueryBuilderQueries";
+
+
+export class QueryBuilderDelete extends QueryBuilderQueries
+{
+
+    parse()
+    {
+        return {
+            type: "REMOVE",
+            at: this.collection,
+            filters: this._where
+        };
+    }
+
+}

--- a/src/QueryBuilder/QueryBuilderUpdate.js
+++ b/src/QueryBuilder/QueryBuilderUpdate.js
@@ -1,0 +1,17 @@
+import { QueryBuilderQueries } from "./QueryBuilderQueries";
+
+
+export class QueryBuilderUpdate extends QueryBuilderQueries
+{
+
+    parse()
+    {
+        return {
+            type: "CHANGE",
+            at: this.collection,
+            data: this.fields,
+            filters: this._where
+        };
+    }
+
+}

--- a/src/QueryBuilder/index.js
+++ b/src/QueryBuilder/index.js
@@ -1,6 +1,7 @@
 import { QueryBuilderInsert } from "./QueryBuilderInsert";
 import { QueryBuilderSelect } from "./QueryBuilderSelect";
 import { QueryBuilderUpdate } from "./QueryBuilderUpdate";
+import { QueryBuilderDelete } from "./QueryBuilderDelete";
 
 
 export class QueryBuilder 
@@ -19,6 +20,11 @@ export class QueryBuilder
     update()
     {
         return new QueryBuilderUpdate();
+    }
+
+    delete()
+    {
+        return new QueryBuilderDelete();
     }
 
 }

--- a/src/QueryBuilder/index.js
+++ b/src/QueryBuilder/index.js
@@ -1,5 +1,6 @@
 import { QueryBuilderInsert } from "./QueryBuilderInsert";
 import { QueryBuilderSelect } from "./QueryBuilderSelect";
+import { QueryBuilderUpdate } from "./QueryBuilderUpdate";
 
 
 export class QueryBuilder 
@@ -13,6 +14,11 @@ export class QueryBuilder
     select()
     {
         return new QueryBuilderSelect();
+    }
+
+    update()
+    {
+        return new QueryBuilderUpdate();
     }
 
 }

--- a/src/QueryCriteria.js
+++ b/src/QueryCriteria.js
@@ -35,15 +35,15 @@ export class QueryCriteria
         return field >= value;
     }
 
-    // in(field, value)
-    // {
-    //     return this.intersectIn(field, value);
-    // }
+    in(field, value)
+    {
+        return value.includes(field);
+    }
 
-    // notin(field, value)
-    // {
-    //     return this.intersectIn(field, value, true);
-    // }
+    notin(field, value)
+    {
+        return !value.includes(field);
+    }
 
     // andX()
     // {
@@ -55,19 +55,4 @@ export class QueryCriteria
     //     return `(${this.intersect(arguments, "OR")})`;
     // }
 
-    // intersect(whatToInsersect, intersectWith)
-    // {
-    //     return Object.keys(whatToInsersect)
-    //         .map(key => whatToInsersect[key])
-    //         .join(` ${intersectWith.trim()} `);
-    // }
-
-    // intersectIn(field, value, not = false)
-    // {
-    //     if (Array.isArray(value))
-    //         value = `(${value.map(v => treatValue(v)).join(", ")})`;
-    //     if (typeof value === "object" && typeof value.parse === "function")
-    //         value = treatValue(value);
-    //     return `${parseFieldAndTable(field)} ${not ? "NOT" : ""} IN ${value}`;
-    // }
 }

--- a/src/QueryCriteria.js
+++ b/src/QueryCriteria.js
@@ -2,57 +2,84 @@ export class QueryCriteria
 {
     like(field, value) 
     {
-        return field.includes(value);
+        return item => item[field].includes(value);
     }
 
     eq(field, value) 
     {
-        return field === value;
+        return item => item[field] === value;
     }
 
     neq(field, value) 
     {
-        return field !== value;
+        return item => item[field] !== value;
     }
 
     lt(field, value)
     {
-        return field < value;
+        return item => item[field] < value;
     }
 
     lte(field, value)
     {
-        return field <= value;
+        return item => item[field] <= value;
     }
 
     gt(field, value)
     {
-        return field > value;
+        return item => item[field] > value;
     }
 
     gte(field, value)
     {
-        return field >= value;
+        return item => item[field] >= value;
     }
 
     in(field, value)
     {
-        return value.includes(field);
+        return item => value.includes(item[field]);
     }
 
     notin(field, value)
     {
-        return !value.includes(field);
+        return item => !value.includes(item[field]);
     }
 
-    // andX()
-    // {
-    //     return `(${this.intersect(arguments, "AND")})`;
-    // }
+    andX()
+    {
+        return item =>
+        {
+            let response = true;
+            this.extractFunctions(arguments).forEach(filter => 
+            {
+                if (!response) return;
 
-    // orX()
-    // {
-    //     return `(${this.intersect(arguments, "OR")})`;
-    // }
+                response = filter(item);
+            });
+
+            return response;
+        };
+    }
+
+    orX()
+    {
+        return item =>
+        {
+            let response = false;
+            this.extractFunctions(arguments).forEach(filter => 
+            {
+                if (response) return;
+
+                response = filter(item);
+            });
+
+            return response;
+        };
+    }
+
+    extractFunctions(filters)
+    {
+        return Object.keys(filters).map(key => filters[key]);
+    }
 
 }

--- a/test/Unit/Connection.test.js
+++ b/test/Unit/Connection.test.js
@@ -34,6 +34,20 @@ describe("Test/Unit/ConnectionTest", () =>
                     }).to.throw(/Missing "at" parameter/))
                 .finally(done);
         });
+
+        it("Should present error when invalid query type", done =>
+        {
+            Connection.query({
+                type: "Adds",
+                at: "Anywhere",
+                data: { name: "any name" }
+            })
+                .catch(err => expect(() => 
+                {
+                    throw err;
+                }).to.throw())
+                .finally(done);
+        });
     });
 
     describe("Add", () => 
@@ -56,7 +70,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(queryResponse).to.have.property("changedRows");
                     USER_ID = queryResponse.lastInsertedId;
                 })
-                .finally(done);
+                .then(done);
         });
 
         it("Should insert multiple data into database", done => 
@@ -97,7 +111,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(queryResponse.affectedRows).to.be.a("number");
                     expect(queryResponse.changedRows).to.be.a("number");
                 })
-                .finally(done);
+                .then(done);
         });
     });
 
@@ -114,7 +128,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(results).to.be.an("Array");
                     expect(results).to.be.lengthOf(4);
                 })
-                .finally(done);
+                .then(done);
         });
 
         it("Should apply some filters", done => 
@@ -133,7 +147,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(results).to.be.an("Array");
                     expect(results).to.be.lengthOf(1);
                 })
-                .finally(done);
+                .then(done);
         });
 
         it("Should paginate results", done => 
@@ -149,7 +163,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(results).to.be.an("array");
                     expect(results).to.be.lengthOf(2);
                 })
-                .finally(done);
+                .then(done);
         });
     });
 
@@ -174,7 +188,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(queryResponse.affectedRows).to.be.equal(1);
                     expect(queryResponse.changedRows).to.be.equal(1);
                 })
-                .finally(done);
+                .then(done);
         });
 
         it("Should run update query but change nothing", done => 
@@ -192,7 +206,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(queryResponse.affectedRows).to.be.equal(1);
                     expect(queryResponse.changedRows).to.be.equal(0);
                 })
-                .finally(done);
+                .then(done);
         });
     });
 
@@ -212,7 +226,7 @@ describe("Test/Unit/ConnectionTest", () =>
                     expect(changedRows).to.be.equal(0);
                     expect(affectedRows).to.be.equal(1);
                 })
-                .finally(done);
+                .then(done);
         });
     });
 

--- a/test/Unit/QueryBuilder.test.js
+++ b/test/Unit/QueryBuilder.test.js
@@ -183,6 +183,28 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .then(results => expect(results).to.be.lengthOf(4))
                     .finally(done);
             });
+
+            it("Should filter by In", done => 
+            {
+                new QueryBuilder()
+                    .select()
+                    .from("schedule_statuses")
+                    .where({ code: { in: [0, 2, 3] } })
+                    .execute()
+                    .then(results => expect(results).to.be.lengthOf(3))
+                    .finally(done);
+            });
+
+            it("Should filter by Not In", done => 
+            {
+                new QueryBuilder()
+                    .select()
+                    .from("schedule_statuses")
+                    .where({ code: { notin: [0, 1] } })
+                    .execute()
+                    .then(results => expect(results).to.be.lengthOf(2))
+                    .finally(done);
+            });
         });
     });
 

--- a/test/Unit/QueryBuilder.test.js
+++ b/test/Unit/QueryBuilder.test.js
@@ -275,6 +275,24 @@ describe("Test/Unit/QueryBuilderTest", () =>
         });
     });
 
+    describe("DeleteQueryBuilder", () => 
+    {
+        it("Should delete filtered results", done => 
+        {
+            new QueryBuilder()
+                .delete()
+                .from("schedule_statuses")
+                .where({ code: { gt: 1 } })
+                .execute()
+                .then(results => 
+                {
+                    expect(results.changedRows).to.be.equal(0);
+                    expect(results.affectedRows).to.be.equal(2);
+                })
+                .then(() => done());
+        });
+    });
+
     after(done => 
     {
         Promise.all([

--- a/test/Unit/QueryBuilder.test.js
+++ b/test/Unit/QueryBuilder.test.js
@@ -256,6 +256,25 @@ describe("Test/Unit/QueryBuilderTest", () =>
         });
     });
 
+    describe("UpdateQueryBuilder", () => 
+    {
+        it("Should update filtered results", done => 
+        {
+            new QueryBuilder()
+                .update()
+                .set({ name: "Doned" })
+                .into("schedule_statuses")
+                .where({ name:  "Done" })
+                .execute()
+                .then(response => 
+                {
+                    expect(response.affectedRows).to.be.equal(1);
+                    expect(response.changedRows).to.be.equal(1);
+                })
+                .then(() => done());
+        });
+    });
+
     after(done => 
     {
         Promise.all([

--- a/test/Unit/QueryBuilder.test.js
+++ b/test/Unit/QueryBuilder.test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { QueryBuilder, Connection } from "./../../src";
+import { QueryBuilder, Connection, QueryCriteria } from "./../../src";
 
 
 describe("Test/Unit/QueryBuilderTest", () => 
@@ -30,7 +30,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     expect(result.affectedRows).to.be.a("number").equals(0);
                     expect(result.changedRows).to.be.a("number").equals(0);
                 })
-                .finally(done);
+                .then(() => done());
         });
     });
 
@@ -58,7 +58,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                         { name: "Cancelled", code: 3 }
                     ]
                 })
-            ]).finally(done);
+            ]).then(() => done());
         });
 
         it("Should select data", done => 
@@ -76,7 +76,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     expect(results[0].name).to.be.a("string");
                     expect(results[0].with_non_existent).to.be.null;
                 })
-                .finally(done);
+                .then(() => done());
         });
 
         describe("Limiting and offseting", () => 
@@ -93,7 +93,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                         expect(results).to.be.an("array");
                         expect(results).to.be.lengthOf(2);
                     })
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should offset results", done => 
@@ -107,7 +107,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     {
                         expect(results).to.be.lengthOf(3);
                     })
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should limit and offset", done => 
@@ -123,7 +123,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                         expect(results).to.be.lengthOf(2);
                         expect(results[0].name).to.be.equal("Done");
                     })
-                    .finally(done);
+                    .then(() => done());
             });
         });
 
@@ -137,7 +137,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ name: "Done" })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(1))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by Greather Than", done => 
@@ -148,7 +148,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { gt: 2 } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(1))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by Greater Than or Equal", done => 
@@ -159,7 +159,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { gte: 2 } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(2))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by Lower Than", done => 
@@ -170,7 +170,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { lt: 3 } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(3))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by Lower Than or Equal", done => 
@@ -181,7 +181,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { lte: 3 } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(4))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by In", done => 
@@ -192,7 +192,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { in: [0, 2, 3] } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(3))
-                    .finally(done);
+                    .then(() => done());
             });
 
             it("Should filter by Not In", done => 
@@ -203,7 +203,55 @@ describe("Test/Unit/QueryBuilderTest", () =>
                     .where({ code: { notin: [0, 1] } })
                     .execute()
                     .then(results => expect(results).to.be.lengthOf(2))
-                    .finally(done);
+                    .then(() => done());
+            });
+
+            it("Should concatenate And filters", done => 
+            {
+                let criteria = new QueryCriteria();
+                new QueryBuilder()
+                    .select()
+                    .from("schedule_statuses")
+                    .where(criteria.andX(
+                        criteria.eq("code", 1),
+                        criteria.eq("name", "Done")
+                    ))
+                    .execute()
+                    .then(results => expect(results).to.be.lengthOf(1))
+                    .then(() => done());
+            });
+
+            it("Should concatenate Or filters", done => 
+            {
+                let criteria = new QueryCriteria();
+                new QueryBuilder()
+                    .select()
+                    .from("schedule_statuses")
+                    .where(criteria.orX(
+                        criteria.eq("name", "Done"),
+                        criteria.eq("code", 0)
+                    ))
+                    .execute()
+                    .then(results => expect(results).to.be.lengthOf(2))
+                    .then(() => done());
+            });
+
+            it("Should concatenate And and Or filters", done => 
+            {
+                let criteria = new QueryCriteria();
+                new QueryBuilder()
+                    .select()
+                    .from("schedule_statuses")
+                    .where(criteria.andX(
+                        criteria.orX(
+                            criteria.eq("code", 1),
+                            criteria.eq("code", 2)
+                        ),
+                        criteria.eq("name", "Done")
+                    ))
+                    .execute()
+                    .then(results => expect(results).to.be.lengthOf(1))
+                    .then(() => done());
             });
         });
     });
@@ -213,7 +261,7 @@ describe("Test/Unit/QueryBuilderTest", () =>
         Promise.all([
             Connection.query({ type: "DROP", at: "schedules" }),
             Connection.query({ type: "DROP", at: "schedule_statuses" })
-        ]).finally(done);
+        ]).then(() => done());
     });
 
 });


### PR DESCRIPTION
Provided QueryCriteria filters are: in(), notin(), andX() and orX().
It also provider an encapsulation on QueryBuilder that permits executing **Remove** and **Change** queries.